### PR TITLE
Update the module name to point to the correct repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/goccy/go-json
+module github.com/rockbot-inc/go-json
 
 go 1.12


### PR DESCRIPTION
I think we need this name change so it can be imported properly. Right now it complains with: 

```
go: github.com/rockbot-inc/go-json@v1.0.0: parsing go.mod:
        module declares its path as: github.com/goccy/go-json
                but was required as: github.com/rockbot-inc/go-json

```